### PR TITLE
Refactor drawers

### DIFF
--- a/src/components/molecules/DrawerConnectedSections/ConnectedElementsSection.tsx
+++ b/src/components/molecules/DrawerConnectedSections/ConnectedElementsSection.tsx
@@ -1,0 +1,64 @@
+import { ChevronRight, ExternalLink } from 'lucide-react'
+import React from 'react'
+
+import { cn } from '../../../utils/cn'
+
+import type { ConnectedElementsSectionProps } from './types'
+
+export const ConnectedElementsSection: React.FC<ConnectedElementsSectionProps> = ({
+	elements,
+	onNavigateToElement,
+	className,
+}) => {
+	if (elements.length === 0) return null
+
+	return (
+		<div className={cn('bg-muted/5 rounded-2xl p-5 border border-border/30', className)}>
+			<div className="flex items-center gap-2 mb-4">
+				<div className="w-5 h-5 rounded-full bg-primary/10 flex items-center justify-center">
+					<ExternalLink className="w-3 h-3 text-primary" />
+				</div>
+				<h3 className="text-sm font-semibold text-foreground">Connected Elements</h3>
+				<div className="ml-auto flex items-center gap-2 px-2 py-1 bg-primary/10 text-primary rounded-full text-xs font-medium">
+					{elements.length}
+				</div>
+			</div>
+			<p className="text-xs text-muted-foreground mb-4">Click any element to view details</p>
+			<div className="space-y-2">
+				{elements.map((element) => (
+					<button
+						key={element.party_element_id}
+						onClick={() => onNavigateToElement?.(element.party_element_id)}
+						disabled={!onNavigateToElement}
+						className={cn(
+							'w-full text-left flex items-center gap-3 p-3 rounded-lg',
+							'bg-background hover:bg-muted/50 transition-colors group mobile-touch-target border border-border/30 hover:border-border/60',
+							!onNavigateToElement && 'cursor-default'
+						)}
+					>
+						{element.image ? (
+							<img
+								src={element.image.image_url}
+								alt={element.element_name}
+								className="w-10 h-10 rounded-lg object-cover flex-shrink-0 border border-border/20"
+							/>
+						) : (
+							<div className="w-10 h-10 rounded-lg bg-muted/50 flex items-center justify-center flex-shrink-0 border border-border/20">
+								<div className="w-4 h-4 rounded bg-muted-foreground/30"></div>
+							</div>
+						)}
+						<span className="text-sm text-foreground flex-1 truncate font-medium">
+							{element.element_name}
+						</span>
+						{onNavigateToElement && (
+							<ChevronRight
+								size={16}
+								className="text-muted-foreground group-hover:text-foreground transition-colors flex-shrink-0"
+							/>
+						)}
+					</button>
+				))}
+			</div>
+		</div>
+	)
+}

--- a/src/components/molecules/DrawerConnectedSections/ConnectedEventsSection.tsx
+++ b/src/components/molecules/DrawerConnectedSections/ConnectedEventsSection.tsx
@@ -1,0 +1,65 @@
+import { Calendar, Clock } from 'lucide-react'
+import React from 'react'
+
+import { cn } from '../../../utils/cn'
+
+import type { ConnectedEventsSectionProps } from './types'
+
+export const ConnectedEventsSection: React.FC<ConnectedEventsSectionProps> = ({
+	events,
+	onNavigateToEvent,
+	className,
+}) => {
+	if (events.length === 0) return null
+
+	const formatDuration = (start: Date, end: Date): string => {
+		const durationMs = end.getTime() - start.getTime()
+		const durationMinutes = Math.floor(durationMs / (1000 * 60))
+		const hours = Math.floor(durationMinutes / 60)
+		const minutes = durationMinutes % 60
+
+		if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`
+		if (hours > 0) return `${hours}h`
+		return `${minutes}m`
+	}
+
+	return (
+		<div className={cn('bg-muted/5 rounded-2xl p-5 border border-border/30', className)}>
+			<div className="flex items-center gap-2 mb-4">
+				<Calendar className="w-5 h-5 text-primary" />
+				<h3 className="text-sm font-semibold text-foreground">Connected Events</h3>
+				<div className="ml-auto flex items-center gap-2 px-2 py-1 bg-primary/10 text-primary rounded-full text-xs font-medium">
+					{events.length}
+				</div>
+			</div>
+			<div className="space-y-2">
+				{events.map((event) => (
+					<button
+						key={event.party_event_id}
+						onClick={() => onNavigateToEvent?.(event.party_event_id)}
+						disabled={!onNavigateToEvent}
+						className={cn(
+							'w-full text-left p-3 rounded-lg',
+							'bg-background hover:bg-muted/50 transition-colors group mobile-touch-target border border-border/30 hover:border-border/60',
+							!onNavigateToEvent && 'cursor-default'
+						)}
+					>
+						<p className="text-sm text-foreground font-medium mb-2">{event.event_name}</p>
+						<div className="flex items-center gap-4 text-xs text-muted-foreground">
+							<div className="flex items-center gap-1">
+								<Clock size={12} />
+								<span>
+									{new Date(event.absoluteStart).toLocaleTimeString([], {
+										hour: '2-digit',
+										minute: '2-digit',
+									})}
+								</span>
+							</div>
+							<span>{formatDuration(event.absoluteStart, event.absoluteEnd)}</span>
+						</div>
+					</button>
+				))}
+			</div>
+		</div>
+	)
+}

--- a/src/components/molecules/DrawerConnectedSections/ConnectedMaterialsSection.tsx
+++ b/src/components/molecules/DrawerConnectedSections/ConnectedMaterialsSection.tsx
@@ -1,0 +1,68 @@
+import { ExternalLink, ShoppingCart } from 'lucide-react'
+import React from 'react'
+
+import { cn } from '../../../utils/cn'
+
+import type { ConnectedMaterialsSectionProps } from './types'
+
+export const ConnectedMaterialsSection: React.FC<ConnectedMaterialsSectionProps> = ({
+	materials,
+	onNavigateToMaterial,
+	className,
+}) => {
+	if (materials.length === 0) return null
+
+	return (
+		<div className={cn('bg-muted/5 rounded-2xl p-5 border border-border/30', className)}>
+			<div className="flex items-center gap-2 mb-4">
+				<ShoppingCart className="w-5 h-5 text-primary" />
+				<h3 className="text-sm font-semibold text-foreground">Connected Materials</h3>
+				<div className="ml-auto flex items-center gap-2 px-2 py-1 bg-primary/10 text-primary rounded-full text-xs font-medium">
+					{materials.length}
+				</div>
+			</div>
+			<div className="space-y-2">
+				{materials.map((material) => (
+					<button
+						key={material.party_element_material_id}
+						onClick={() => onNavigateToMaterial?.(material.party_element_material_id)}
+						disabled={!onNavigateToMaterial}
+						className={cn(
+							'w-full text-left p-3 rounded-lg',
+							'bg-background hover:bg-muted/50 transition-colors group mobile-touch-target border border-border/30 hover:border-border/60',
+							!onNavigateToMaterial && 'cursor-default'
+						)}
+					>
+						<div className="flex items-start justify-between gap-2">
+							<div className="flex-1 min-w-0">
+								<div className="flex items-center gap-2 mb-1">
+									<span
+										className={cn(
+											'px-2 py-0.5 text-xs font-semibold rounded-full',
+											material.status === 'purchased'
+												? 'bg-green-100 text-green-800'
+												: material.status === 'needed'
+													? 'bg-yellow-100 text-yellow-800'
+													: 'bg-gray-100 text-gray-800'
+										)}
+									>
+										{material.status}
+									</span>
+								</div>
+								<p className="text-sm text-foreground font-medium truncate">
+									{material.party_element_material_name}
+								</p>
+							</div>
+						</div>
+						{material.link && (
+							<div className="flex items-center gap-1.5 mt-2 text-xs text-muted-foreground">
+								<ExternalLink size={12} />
+								<span className="truncate">Shopping link available</span>
+							</div>
+						)}
+					</button>
+				))}
+			</div>
+		</div>
+	)
+}

--- a/src/components/molecules/DrawerConnectedSections/ConnectedTasksSection.tsx
+++ b/src/components/molecules/DrawerConnectedSections/ConnectedTasksSection.tsx
@@ -1,0 +1,66 @@
+import { Calendar, CheckCircle2 } from 'lucide-react'
+import React from 'react'
+
+import { cn } from '../../../utils/cn'
+
+import type { ConnectedTasksSectionProps } from './types'
+
+export const ConnectedTasksSection: React.FC<ConnectedTasksSectionProps> = ({
+	tasks,
+	onNavigateToTask,
+	className,
+}) => {
+	if (tasks.length === 0) return null
+
+	return (
+		<div className={cn('bg-muted/5 rounded-2xl p-5 border border-border/30', className)}>
+			<div className="flex items-center gap-2 mb-4">
+				<CheckCircle2 className="w-5 h-5 text-primary" />
+				<h3 className="text-sm font-semibold text-foreground">Connected Tasks</h3>
+				<div className="ml-auto flex items-center gap-2 px-2 py-1 bg-primary/10 text-primary rounded-full text-xs font-medium">
+					{tasks.length}
+				</div>
+			</div>
+			<div className="space-y-2">
+				{tasks.map((task) => (
+					<button
+						key={task.party_task_id}
+						onClick={() => onNavigateToTask?.(task.party_task_id)}
+						disabled={!onNavigateToTask}
+						className={cn(
+							'w-full text-left p-3 rounded-lg',
+							'bg-background hover:bg-muted/50 transition-colors group mobile-touch-target border border-border/30 hover:border-border/60',
+							!onNavigateToTask && 'cursor-default'
+						)}
+					>
+						<div className="flex items-start justify-between gap-2">
+							<div className="flex-1 min-w-0">
+								<div className="flex items-center gap-2 mb-1">
+									<span
+										className={cn(
+											'px-2 py-0.5 text-xs font-semibold rounded-full',
+											task.completed_on
+												? 'bg-green-100 text-green-800'
+												: 'bg-yellow-100 text-yellow-800'
+										)}
+									>
+										{task.completed_on ? 'Completed' : 'Pending'}
+									</span>
+								</div>
+								<p className="text-sm text-foreground font-medium truncate">
+									{task.party_task_name}
+								</p>
+							</div>
+						</div>
+						{task.due_date && (
+							<div className="flex items-center gap-1.5 mt-2 text-xs text-muted-foreground">
+								<Calendar size={12} />
+								<span>{new Date(task.due_date).toLocaleDateString()}</span>
+							</div>
+						)}
+					</button>
+				))}
+			</div>
+		</div>
+	)
+}

--- a/src/components/molecules/DrawerConnectedSections/index.ts
+++ b/src/components/molecules/DrawerConnectedSections/index.ts
@@ -1,0 +1,10 @@
+export { ConnectedElementsSection } from './ConnectedElementsSection'
+export { ConnectedTasksSection } from './ConnectedTasksSection'
+export { ConnectedMaterialsSection } from './ConnectedMaterialsSection'
+export { ConnectedEventsSection } from './ConnectedEventsSection'
+export type {
+	ConnectedElementsSectionProps,
+	ConnectedTasksSectionProps,
+	ConnectedMaterialsSectionProps,
+	ConnectedEventsSectionProps,
+} from './types'

--- a/src/components/molecules/DrawerConnectedSections/types.ts
+++ b/src/components/molecules/DrawerConnectedSections/types.ts
@@ -1,0 +1,50 @@
+import type React from 'react'
+
+// Connected Elements Section
+export interface ConnectedElementsSectionProps {
+	elements: Array<{
+		party_element_id: string
+		element_name: string
+		image?: {
+			image_url: string
+		} | null
+	}>
+	onNavigateToElement?: (elementId: string) => void
+	className?: string
+}
+
+// Connected Tasks Section
+export interface ConnectedTasksSectionProps {
+	tasks: Array<{
+		party_task_id: string
+		party_task_name: string
+		completed_on: Date | null
+		due_date?: Date | null
+	}>
+	onNavigateToTask?: (taskId: string) => void
+	className?: string
+}
+
+// Connected Materials Section
+export interface ConnectedMaterialsSectionProps {
+	materials: Array<{
+		party_element_material_id: string
+		party_element_material_name: string
+		status: 'purchased' | 'needed' | 'not_needed' | 'recommended' | 'ignored'
+		link?: string | null
+	}>
+	onNavigateToMaterial?: (materialId: string) => void
+	className?: string
+}
+
+// Connected Events Section
+export interface ConnectedEventsSectionProps {
+	events: Array<{
+		party_event_id: string
+		event_name: string
+		absoluteStart: Date
+		absoluteEnd: Date
+	}>
+	onNavigateToEvent?: (eventId: string) => void
+	className?: string
+}

--- a/src/components/molecules/DrawerFooter/DrawerFooter.tsx
+++ b/src/components/molecules/DrawerFooter/DrawerFooter.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import { cn } from '../../../utils/cn'
+
+import type { DrawerFooterProps } from './types'
+
+export const DrawerFooter: React.FC<DrawerFooterProps> = ({
+	primaryAction,
+	secondaryAction,
+	className,
+}) => {
+	return (
+		<div className={cn('bg-background border-t border-border/30 p-4 flex-shrink-0', className)}>
+			<div className="flex flex-col sm:flex-row gap-3">
+				{secondaryAction && (
+					<button
+						type="button"
+						onClick={secondaryAction.onClick}
+						disabled={secondaryAction.disabled}
+						className="order-2 sm:order-1 w-full sm:w-auto px-4 py-2.5 rounded-lg border border-border hover:bg-muted transition-colors text-sm font-medium mobile-touch-target disabled:opacity-50"
+					>
+						{secondaryAction.label}
+					</button>
+				)}
+				<button
+					type="button"
+					onClick={primaryAction.onClick}
+					disabled={primaryAction.disabled || primaryAction.loading}
+					className={cn(
+						'order-1 sm:order-2 w-full sm:w-auto px-4 py-2.5 rounded-lg bg-primary hover:bg-primary/90 text-primary-foreground transition-colors text-sm font-medium mobile-touch-target disabled:opacity-50',
+						primaryAction.loading && 'cursor-not-allowed'
+					)}
+				>
+					{primaryAction.loading ? 'Loading...' : primaryAction.label}
+				</button>
+			</div>
+		</div>
+	)
+}

--- a/src/components/molecules/DrawerFooter/index.ts
+++ b/src/components/molecules/DrawerFooter/index.ts
@@ -1,0 +1,2 @@
+export { DrawerFooter } from './DrawerFooter'
+export type { DrawerFooterProps } from './types'

--- a/src/components/molecules/DrawerFooter/types.ts
+++ b/src/components/molecules/DrawerFooter/types.ts
@@ -1,0 +1,14 @@
+export interface DrawerFooterProps {
+	primaryAction: {
+		label: string
+		onClick: () => void | Promise<void>
+		loading?: boolean
+		disabled?: boolean
+	}
+	secondaryAction?: {
+		label: string
+		onClick: () => void
+		disabled?: boolean
+	}
+	className?: string
+}

--- a/src/components/molecules/DrawerHeader/DrawerHeader.tsx
+++ b/src/components/molecules/DrawerHeader/DrawerHeader.tsx
@@ -1,0 +1,102 @@
+import { Copy, Trash2, X } from 'lucide-react'
+import React, { useState } from 'react'
+
+import { cn } from '../../../utils/cn'
+
+import type { DrawerHeaderProps } from './types'
+
+export const DrawerHeader: React.FC<DrawerHeaderProps> = ({
+	title,
+	onClose,
+	onDelete,
+	showDelete = false,
+	showDuplicate = false,
+	onDuplicate,
+	isDuplicating = false,
+	className,
+}) => {
+	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+	const [isDeleting, setIsDeleting] = useState(false)
+
+	const handleDelete = async () => {
+		if (!onDelete) return
+
+		setIsDeleting(true)
+		try {
+			await onDelete()
+			setShowDeleteConfirm(false)
+		} catch (error) {
+			console.error('Failed to delete:', error)
+		} finally {
+			setIsDeleting(false)
+		}
+	}
+
+	return (
+		<div
+			className={cn(
+				'flex items-center justify-between p-4 border-b border-border flex-shrink-0',
+				className
+			)}
+		>
+			<h2 className="text-lg font-semibold text-foreground">{title}</h2>
+			<div className="flex items-center gap-2">
+				{/* Duplicate Button */}
+				{showDuplicate && onDuplicate && (
+					<button
+						type="button"
+						onClick={onDuplicate}
+						disabled={isDuplicating}
+						className="p-2 hover:bg-muted rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-primary/20 mobile-touch-target flex items-center justify-center"
+						aria-label="Duplicate"
+					>
+						<Copy className="w-4 h-4 text-muted-foreground" />
+					</button>
+				)}
+				{/* Delete Button (Edit Mode Only) */}
+				{showDelete && onDelete && (
+					<>
+						{showDeleteConfirm ? (
+							<>
+								<span className="text-sm text-muted-foreground">Delete?</span>
+								<button
+									type="button"
+									onClick={() => setShowDeleteConfirm(false)}
+									disabled={isDeleting}
+									className="py-1.5 px-3 rounded-lg border border-border hover:bg-muted transition-colors text-sm font-medium mobile-touch-target"
+								>
+									Cancel
+								</button>
+								<button
+									type="button"
+									onClick={handleDelete}
+									disabled={isDeleting}
+									className="py-1.5 px-3 rounded-lg bg-destructive hover:bg-destructive/90 text-destructive-foreground transition-colors text-sm font-medium disabled:opacity-50 mobile-touch-target"
+								>
+									{isDeleting ? 'Deleting...' : 'Delete'}
+								</button>
+							</>
+						) : (
+							<button
+								type="button"
+								onClick={() => setShowDeleteConfirm(true)}
+								className="p-2 hover:bg-muted rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-primary/20 mobile-touch-target flex items-center justify-center"
+								aria-label="Delete"
+							>
+								<Trash2 className="w-4 h-4 text-muted-foreground" />
+							</button>
+						)}
+					</>
+				)}
+				{/* Close Button */}
+				<button
+					onClick={onClose}
+					className="p-2 hover:bg-muted rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-primary/20 mobile-touch-target flex items-center justify-center"
+					aria-label="Close drawer"
+				>
+					<X size={16} />
+				</button>
+			</div>
+		</div>
+	)
+}

--- a/src/components/molecules/DrawerHeader/index.ts
+++ b/src/components/molecules/DrawerHeader/index.ts
@@ -1,0 +1,2 @@
+export { DrawerHeader } from './DrawerHeader'
+export type { DrawerHeaderProps } from './types'

--- a/src/components/molecules/DrawerHeader/types.ts
+++ b/src/components/molecules/DrawerHeader/types.ts
@@ -1,0 +1,11 @@
+export interface DrawerHeaderProps {
+	title: string
+	onClose: () => void
+	onDelete?: () => Promise<void>
+	showDelete?: boolean
+	className?: string
+	// Duplicate button support
+	showDuplicate?: boolean
+	onDuplicate?: () => void
+	isDuplicating?: boolean
+}

--- a/src/components/molecules/StatusDropdown/StatusDropdown.tsx
+++ b/src/components/molecules/StatusDropdown/StatusDropdown.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react'
+
+import { cn } from '../../../utils/cn'
+
+import type { StatusDropdownProps } from './types'
+
+export const StatusDropdown: React.FC<StatusDropdownProps> = ({
+	currentStatus,
+	onStatusChange,
+	className,
+}) => {
+	const [isOpen, setIsOpen] = useState(false)
+	const statuses: Array<'pending' | 'approved' | 'rejected'> = ['pending', 'approved', 'rejected']
+
+	const getStatusColor = (status: string) => {
+		switch (status) {
+			case 'approved':
+				return 'bg-green-100 text-green-800 border-green-200'
+			case 'rejected':
+				return 'bg-red-100 text-red-800 border-red-200'
+			default:
+				return 'bg-yellow-100 text-yellow-800 border-yellow-200'
+		}
+	}
+
+	const getStatusLabel = (status: string) => {
+		switch (status) {
+			case 'approved':
+				return 'Approved'
+			case 'rejected':
+				return 'Rejected'
+			default:
+				return 'Pending'
+		}
+	}
+
+	return (
+		<div className={cn('relative', className)}>
+			<button
+				onClick={() => setIsOpen(!isOpen)}
+				className={cn(
+					'px-3 py-1 rounded-full text-xs font-medium border transition-all duration-200 hover-scale',
+					getStatusColor(currentStatus)
+				)}
+			>
+				{getStatusLabel(currentStatus)}
+			</button>
+			{isOpen && (
+				<div className="absolute top-full left-0 mt-1 bg-background border border-border rounded-lg shadow-xl z-10 min-w-[120px] overflow-hidden animate-fade-in-up">
+					{statuses.map((status, index) => (
+						<button
+							key={status}
+							onClick={() => {
+								onStatusChange(status)
+								setIsOpen(false)
+							}}
+							className={cn(
+								'w-full text-left px-3 py-2 text-sm hover:bg-muted transition-all duration-200 first:rounded-t-lg last:rounded-b-lg hover-scale animate-fade-in-up',
+								getStatusColor(status)
+							)}
+							style={{ animationDelay: `${index * 0.05}s` }}
+						>
+							{getStatusLabel(status)}
+						</button>
+					))}
+				</div>
+			)}
+		</div>
+	)
+}

--- a/src/components/molecules/StatusDropdown/index.ts
+++ b/src/components/molecules/StatusDropdown/index.ts
@@ -1,0 +1,3 @@
+export { StatusDropdown } from './StatusDropdown'
+export type { StatusDropdownProps } from './types'
+export type { SuggestionStatus } from './types'

--- a/src/components/molecules/StatusDropdown/types.ts
+++ b/src/components/molecules/StatusDropdown/types.ts
@@ -1,0 +1,16 @@
+export type SuggestionStatus = 'pending' | 'approved' | 'rejected'
+
+export interface StatusDropdownProps {
+	/**
+	 * Current status value
+	 */
+	currentStatus: SuggestionStatus
+	/**
+	 * Callback when status changes
+	 */
+	onStatusChange: (status: SuggestionStatus) => void
+	/**
+	 * Optional className for styling
+	 */
+	className?: string
+}

--- a/src/components/organisms/ConnectedItemsSection/ConnectedItemsSection.tsx
+++ b/src/components/organisms/ConnectedItemsSection/ConnectedItemsSection.tsx
@@ -1,0 +1,64 @@
+import { ChevronRight, ExternalLink } from 'lucide-react'
+import React from 'react'
+
+import { cn } from '../../../utils/cn'
+
+import type { ConnectedItemsSectionProps } from './types'
+
+export const ConnectedItemsSection: React.FC<ConnectedItemsSectionProps> = ({
+	items,
+	title,
+	onItemClick,
+	icon,
+	// emptyMessage = 'No items connected',
+	className,
+}) => {
+	if (!items || items.length === 0) {
+		return null
+	}
+
+	return (
+		<div className={cn('bg-muted/5 rounded-2xl p-5 border border-border/30', className)}>
+			<div className="flex items-center gap-2 mb-4">
+				<div className="w-5 h-5 rounded-full bg-primary/10 flex items-center justify-center">
+					{icon || <ExternalLink className="w-3 h-3 text-primary" />}
+				</div>
+				<h3 className="text-sm font-semibold text-foreground">{title}</h3>
+				<div className="ml-auto flex items-center gap-2 px-2 py-1 bg-primary/10 text-primary rounded-full text-xs font-medium">
+					{items.length}
+				</div>
+			</div>
+			<p className="text-xs text-muted-foreground mb-4">Click any item to view details</p>
+			<div className="space-y-2">
+				{items.map((item) => (
+					<button
+						key={item.id}
+						onClick={() => onItemClick(item.id)}
+						className={cn(
+							'w-full text-left flex items-center gap-3 p-3 rounded-lg',
+							'bg-background hover:bg-muted/50 transition-colors group mobile-touch-target border border-border/30 hover:border-border/60'
+						)}
+					>
+						{item.image ? (
+							<img
+								src={item.image.image_url}
+								alt={item.name}
+								className="w-10 h-10 rounded-lg object-cover flex-shrink-0 border border-border/20"
+							/>
+						) : (
+							<div className="w-10 h-10 rounded-lg bg-muted/50 flex items-center justify-center flex-shrink-0 border border-border/20">
+								<div className="w-4 h-4 rounded bg-muted-foreground/30"></div>
+							</div>
+						)}
+						<span className="text-sm text-foreground flex-1 truncate font-medium">{item.name}</span>
+						<ChevronRight
+							size={16}
+							className="text-muted-foreground group-hover:text-foreground transition-colors flex-shrink-0"
+						/>
+					</button>
+				))}
+			</div>
+		</div>
+	)
+}
+

--- a/src/components/organisms/ConnectedItemsSection/index.ts
+++ b/src/components/organisms/ConnectedItemsSection/index.ts
@@ -1,0 +1,3 @@
+export { ConnectedItemsSection } from './ConnectedItemsSection'
+export type { ConnectedItemsSectionProps, ConnectedItem } from './types'
+

--- a/src/components/organisms/ConnectedItemsSection/types.ts
+++ b/src/components/organisms/ConnectedItemsSection/types.ts
@@ -1,0 +1,20 @@
+import type React from 'react'
+
+export interface ConnectedItem {
+	id: string
+	name: string
+	image?: {
+		image_url: string
+	} | null
+	[key: string]: any
+}
+
+export interface ConnectedItemsSectionProps {
+	items: ConnectedItem[]
+	title: string
+	onItemClick: (itemId: string) => void
+	icon?: React.ReactNode
+	emptyMessage?: string
+	className?: string
+}
+

--- a/src/components/organisms/DrawerFooter/DrawerFooter.tsx
+++ b/src/components/organisms/DrawerFooter/DrawerFooter.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+
+import { cn } from '../../../utils/cn'
+import { Button } from '../../atoms/Button'
+
+import type { DrawerFooterProps } from './types'
+
+export const DrawerFooter: React.FC<DrawerFooterProps> = ({
+	onCancel,
+	onSave,
+	onPrimaryAction,
+	primaryLabel = 'Save',
+	cancelLabel = 'Cancel',
+	showCancel = true,
+	showSave = true,
+	isLoading = false,
+	isSaving = false,
+	disabled = false,
+	className,
+	children,
+}) => {
+	const handlePrimaryAction = () => {
+		if (onPrimaryAction) {
+			onPrimaryAction()
+		} else if (onSave) {
+			onSave()
+		}
+	}
+
+	return (
+		<div className={cn('bg-background border-t border-border/30 p-4 flex-shrink-0', className)}>
+			{children ? (
+				children
+			) : (
+				<div className="flex flex-col sm:flex-row gap-3">
+					{showCancel && (
+						<Button
+							variant="secondary"
+							size="md"
+							onClick={onCancel}
+							disabled={isLoading || isSaving}
+							className="order-2 sm:order-1 w-full sm:w-auto rounded-lg"
+						>
+							{cancelLabel}
+						</Button>
+					)}
+					{showSave && (onSave || onPrimaryAction) && (
+						<Button
+							variant="default"
+							size="md"
+							onClick={handlePrimaryAction}
+							disabled={disabled || isLoading || isSaving}
+							loading={isSaving}
+							className="order-1 sm:order-2 w-full sm:w-auto rounded-lg"
+						>
+							{primaryLabel}
+						</Button>
+					)}
+				</div>
+			)}
+		</div>
+	)
+}
+

--- a/src/components/organisms/DrawerFooter/index.ts
+++ b/src/components/organisms/DrawerFooter/index.ts
@@ -1,0 +1,3 @@
+export { DrawerFooter } from './DrawerFooter'
+export type { DrawerFooterProps } from './types'
+

--- a/src/components/organisms/DrawerFooter/types.ts
+++ b/src/components/organisms/DrawerFooter/types.ts
@@ -1,0 +1,17 @@
+import type React from 'react'
+
+export interface DrawerFooterProps {
+	onCancel: () => void
+	onSave?: () => void
+	onPrimaryAction?: () => void
+	primaryLabel?: string
+	cancelLabel?: string
+	showCancel?: boolean
+	showSave?: boolean
+	isLoading?: boolean
+	isSaving?: boolean
+	disabled?: boolean
+	className?: string
+	children?: React.ReactNode
+}
+

--- a/src/components/organisms/DrawerHeader/DrawerHeader.tsx
+++ b/src/components/organisms/DrawerHeader/DrawerHeader.tsx
@@ -1,0 +1,99 @@
+import { Copy, Trash2, X as XIcon } from 'lucide-react'
+import React, { useState } from 'react'
+
+import { cn } from '../../../utils/cn'
+
+import type { DrawerHeaderProps } from './types'
+
+export const DrawerHeader: React.FC<DrawerHeaderProps> = ({
+	title,
+	onClose,
+	showDelete = false,
+	onDelete,
+	isDeleting = false,
+	showCloseButton = true,
+	showDuplicate = false,
+	onDuplicate,
+	isDuplicating = false,
+	className,
+}) => {
+	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+
+	const handleDelete = async () => {
+		if (onDelete) {
+			await onDelete()
+			setShowDeleteConfirm(false)
+		}
+	}
+
+	return (
+		<div
+			className={cn(
+				'flex items-center justify-between p-4 border-b border-border flex-shrink-0',
+				className
+			)}
+		>
+			<h2 className="text-lg font-semibold text-foreground">{title}</h2>
+			<div className="flex items-center gap-2">
+				{/* Duplicate Button */}
+				{showDuplicate && onDuplicate && (
+					<button
+						type="button"
+						onClick={onDuplicate}
+						disabled={isDuplicating}
+						className="p-2 hover:bg-muted rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-primary/20 mobile-touch-target flex items-center justify-center"
+						aria-label="Duplicate"
+					>
+						<Copy className="w-4 h-4 text-muted-foreground" />
+					</button>
+				)}
+				{/* Delete Button (with inline confirmation) */}
+				{showDelete && onDelete && (
+					<>
+						{showDeleteConfirm ? (
+							<>
+								<span className="text-sm text-muted-foreground">Delete?</span>
+								<button
+									type="button"
+									onClick={() => setShowDeleteConfirm(false)}
+									disabled={isDeleting}
+									className="py-1.5 px-3 rounded-lg border border-border hover:bg-muted transition-colors text-sm font-medium mobile-touch-target"
+								>
+									Cancel
+								</button>
+								<button
+									type="button"
+									onClick={handleDelete}
+									disabled={isDeleting}
+									className="py-1.5 px-3 rounded-lg bg-destructive hover:bg-destructive/90 text-destructive-foreground transition-colors text-sm font-medium disabled:opacity-50 mobile-touch-target"
+								>
+									{isDeleting ? 'Deleting...' : 'Delete'}
+								</button>
+							</>
+						) : (
+							<button
+								type="button"
+								onClick={() => setShowDeleteConfirm(true)}
+								className="p-2 hover:bg-muted rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-primary/20 mobile-touch-target flex items-center justify-center"
+								aria-label="Delete"
+							>
+								<Trash2 className="w-4 h-4 text-muted-foreground" />
+							</button>
+						)}
+					</>
+				)}
+				{/* Close Button */}
+				{showCloseButton && (
+					<button
+						onClick={onClose}
+						className="p-2 hover:bg-muted rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-primary/20 mobile-touch-target flex items-center justify-center"
+						aria-label="Close drawer"
+					>
+						<XIcon size={16} />
+					</button>
+				)}
+			</div>
+		</div>
+	)
+}
+

--- a/src/components/organisms/DrawerHeader/DrawerHeader.tsx
+++ b/src/components/organisms/DrawerHeader/DrawerHeader.tsx
@@ -16,6 +16,7 @@ export const DrawerHeader: React.FC<DrawerHeaderProps> = ({
 	onDuplicate,
 	isDuplicating = false,
 	className,
+	titleContent,
 }) => {
 	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
@@ -33,7 +34,10 @@ export const DrawerHeader: React.FC<DrawerHeaderProps> = ({
 				className
 			)}
 		>
-			<h2 className="text-lg font-semibold text-foreground">{title}</h2>
+			<div className="flex items-center gap-3 flex-1 min-w-0">
+				<h2 className="text-lg font-semibold text-foreground">{title}</h2>
+				{titleContent}
+			</div>
 			<div className="flex items-center gap-2">
 				{/* Duplicate Button */}
 				{showDuplicate && onDuplicate && (
@@ -96,4 +100,3 @@ export const DrawerHeader: React.FC<DrawerHeaderProps> = ({
 		</div>
 	)
 }
-

--- a/src/components/organisms/DrawerHeader/index.ts
+++ b/src/components/organisms/DrawerHeader/index.ts
@@ -1,0 +1,3 @@
+export { DrawerHeader } from './DrawerHeader'
+export type { DrawerHeaderProps } from './types'
+

--- a/src/components/organisms/DrawerHeader/types.ts
+++ b/src/components/organisms/DrawerHeader/types.ts
@@ -1,0 +1,16 @@
+import type React from 'react'
+
+export interface DrawerHeaderProps {
+	title: string | React.ReactNode
+	onClose: () => void
+	showDelete?: boolean
+	onDelete?: () => void
+	isDeleting?: boolean
+	showCloseButton?: boolean
+	className?: string
+	// Duplicate button support
+	showDuplicate?: boolean
+	onDuplicate?: () => void
+	isDuplicating?: boolean
+}
+

--- a/src/components/organisms/DrawerHeader/types.ts
+++ b/src/components/organisms/DrawerHeader/types.ts
@@ -12,5 +12,6 @@ export interface DrawerHeaderProps {
 	showDuplicate?: boolean
 	onDuplicate?: () => void
 	isDuplicating?: boolean
+	// Custom title content (for additional elements like badges, dropdowns, etc.)
+	titleContent?: React.ReactNode
 }
-

--- a/src/components/organisms/EditableField/EditableField.tsx
+++ b/src/components/organisms/EditableField/EditableField.tsx
@@ -1,0 +1,192 @@
+import { Edit, Save, X } from 'lucide-react'
+import React, { useEffect, useState } from 'react'
+
+import { cn } from '../../../utils/cn'
+
+import type { EditableFieldProps } from './types'
+
+export const EditableField = React.forwardRef<
+	HTMLTextAreaElement | HTMLInputElement,
+	EditableFieldProps
+>(
+	(
+		{
+			value,
+			onSave,
+			onCancel,
+			placeholder,
+			className = '',
+			multiline = false,
+			showEditIcon = true,
+			onClick,
+			forceEditing = false,
+			validation,
+			autoFocus = false,
+		},
+		ref
+	) => {
+		const [editValue, setEditValue] = useState(value)
+		const [isEditing, setIsEditing] = useState(forceEditing)
+		const [error, setError] = useState<string | null>(null)
+
+		useEffect(() => {
+			setEditValue(value)
+		}, [value])
+
+		useEffect(() => {
+			setIsEditing(forceEditing)
+		}, [forceEditing])
+
+		const handleSave = () => {
+			const trimmedValue = editValue.trim()
+
+			// Run validation if provided
+			if (validation) {
+				const validationError = validation(trimmedValue)
+				if (validationError) {
+					setError(validationError)
+					return
+				}
+			}
+
+			// Clear error
+			setError(null)
+
+			if (trimmedValue !== value.trim()) {
+				onSave(trimmedValue)
+			}
+			setIsEditing(false)
+		}
+
+		const handleCancel = () => {
+			setEditValue(value)
+			setIsEditing(false)
+			setError(null)
+			onCancel?.()
+		}
+
+		const handleKeyDown = (e: React.KeyboardEvent) => {
+			if (e.key === 'Enter' && !e.shiftKey) {
+				e.preventDefault()
+				handleSave()
+			} else if (e.key === 'Escape') {
+				handleCancel()
+			}
+		}
+
+		if (!isEditing) {
+			return (
+				<div
+					className={cn(
+						'group cursor-pointer hover:scale-101 active:scale-99 transition-transform duration-200',
+						className
+					)}
+					onClick={() => {
+						setIsEditing(true)
+						onClick?.()
+					}}
+					data-editable="true"
+				>
+					{multiline ? (
+						<p className="text-muted-foreground text-sm leading-relaxed group-hover:bg-muted/50 rounded p-2 transition-all duration-200">
+							{value || placeholder || 'Click to add description...'}
+						</p>
+					) : (
+						<h2 className="text-base sm:text-lg font-semibold truncate group-hover:bg-muted/50 rounded p-2 transition-all duration-200">
+							{value || placeholder || 'Click to add name...'}
+						</h2>
+					)}
+					{showEditIcon && (
+						<div className="opacity-0 group-hover:opacity-100 transition-all duration-200 flex items-center gap-1">
+							<div className="animate-pulse">
+								<Edit size={14} className="text-muted-foreground" />
+							</div>
+							<span className="text-xs text-muted-foreground">Click to edit</span>
+						</div>
+					)}
+				</div>
+			)
+		}
+
+		if (multiline) {
+			return (
+				<div className={cn('space-y-2 animate-fade-in-up', className)}>
+					<textarea
+						ref={ref as React.Ref<HTMLTextAreaElement>}
+						value={editValue}
+						onChange={(e) => {
+							setEditValue(e.target.value)
+							setError(null)
+						}}
+						onKeyDown={handleKeyDown}
+						placeholder={placeholder || 'Enter description...'}
+						className={cn(
+							'w-full p-2 border rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all duration-200',
+							error ? 'border-destructive' : 'border-border'
+						)}
+						rows={3}
+						autoFocus={autoFocus}
+					/>
+					{error && <p className="text-xs text-destructive">{error}</p>}
+					<div className="flex gap-2 animate-fade-in-up animate-delay-100">
+						<button
+							onClick={handleSave}
+							className="px-3 py-1 bg-primary text-primary-foreground rounded text-sm hover:bg-primary/90 transition-all duration-200 hover-scale flex items-center gap-1"
+						>
+							<Save size={14} />
+							Save
+						</button>
+						<button
+							onClick={handleCancel}
+							className="px-3 py-1 bg-muted text-foreground rounded text-sm hover:bg-muted/80 transition-all duration-200 hover-scale flex items-center gap-1"
+						>
+							<X size={14} />
+							Cancel
+						</button>
+					</div>
+				</div>
+			)
+		}
+
+		return (
+			<div className={cn('space-y-2 animate-fade-in-up', className)}>
+				<input
+					ref={ref as React.Ref<HTMLInputElement>}
+					type="text"
+					value={editValue}
+					onChange={(e) => {
+						setEditValue(e.target.value)
+						setError(null)
+					}}
+					onKeyDown={handleKeyDown}
+					placeholder={placeholder || 'Enter name...'}
+					className={cn(
+						'w-full p-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/20 transition-all duration-200 hover-scale',
+						error ? 'border-destructive' : 'border-border'
+					)}
+					autoFocus={autoFocus}
+				/>
+				{error && <p className="text-xs text-destructive">{error}</p>}
+				<div className="flex gap-2 animate-fade-in-up animate-delay-100">
+					<button
+						onClick={handleSave}
+						className="px-3 py-1 bg-primary text-primary-foreground rounded text-sm hover:bg-primary/90 transition-all duration-200 hover-scale flex items-center gap-1"
+					>
+						<Save size={14} />
+						Save
+					</button>
+					<button
+						onClick={handleCancel}
+						className="px-3 py-1 bg-muted text-foreground rounded text-sm hover:bg-muted/80 transition-all duration-200 hover-scale flex items-center gap-1"
+					>
+						<X size={14} />
+						Cancel
+					</button>
+				</div>
+			</div>
+		)
+	}
+)
+
+EditableField.displayName = 'EditableField'
+

--- a/src/components/organisms/EditableField/EditableTextArea.tsx
+++ b/src/components/organisms/EditableField/EditableTextArea.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+
+import { EditableField } from './EditableField'
+
+import type { EditableFieldProps } from './types'
+
+export interface EditableTextAreaProps extends EditableFieldProps {
+	/**
+	 * Minimum character length validation
+	 */
+	minLength?: number
+	/**
+	 * Maximum character length validation
+	 */
+	maxLength?: number
+	/**
+	 * Number of rows for the textarea
+	 */
+	rows?: number
+}
+
+export const EditableTextArea = React.forwardRef<HTMLTextAreaElement, EditableTextAreaProps>(
+	({ minLength = 2, maxLength, validation, rows = 3, ...props }, ref) => {
+		const validate = (value: string): string | null => {
+			// Run custom validation if provided
+			if (validation) {
+				const customError = validation(value)
+				if (customError) return customError
+			}
+
+			// Check minimum length
+			if (value.length < minLength) {
+				return `Must be at least ${minLength} characters`
+			}
+
+			// Check maximum length
+			if (maxLength && value.length > maxLength) {
+				return `Must be ${maxLength} characters or less`
+			}
+
+			return null
+		}
+
+		return <EditableField ref={ref} {...props} multiline validation={validate} />
+	}
+)
+
+EditableTextArea.displayName = 'EditableTextArea'
+

--- a/src/components/organisms/EditableField/EditableTextField.tsx
+++ b/src/components/organisms/EditableField/EditableTextField.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+import { EditableField } from './EditableField'
+
+import type { EditableFieldProps } from './types'
+
+export interface EditableTextFieldProps extends Omit<EditableFieldProps, 'multiline'> {
+	/**
+	 * Minimum character length validation
+	 */
+	minLength?: number
+	/**
+	 * Maximum character length validation
+	 */
+	maxLength?: number
+}
+
+export const EditableTextField = React.forwardRef<HTMLInputElement, EditableTextFieldProps>(
+	({ minLength = 2, maxLength, validation, ...props }, ref) => {
+		const validate = (value: string): string | null => {
+			// Run custom validation if provided
+			if (validation) {
+				const customError = validation(value)
+				if (customError) return customError
+			}
+
+			// Check minimum length
+			if (value.length < minLength) {
+				return `Must be at least ${minLength} characters`
+			}
+
+			// Check maximum length
+			if (maxLength && value.length > maxLength) {
+				return `Must be ${maxLength} characters or less`
+			}
+
+			return null
+		}
+
+		return <EditableField ref={ref} {...props} validation={validate} />
+	}
+)
+
+EditableTextField.displayName = 'EditableTextField'
+

--- a/src/components/organisms/EditableField/index.ts
+++ b/src/components/organisms/EditableField/index.ts
@@ -1,0 +1,7 @@
+export { EditableField } from './EditableField'
+export { EditableTextField } from './EditableTextField'
+export { EditableTextArea } from './EditableTextArea'
+export type { EditableFieldProps } from './types'
+export type { EditableTextFieldProps } from './EditableTextField'
+export type { EditableTextAreaProps } from './EditableTextArea'
+

--- a/src/components/organisms/EditableField/types.ts
+++ b/src/components/organisms/EditableField/types.ts
@@ -1,0 +1,22 @@
+import type React from 'react'
+
+export interface EditableFieldProps {
+	value: string
+	onSave: (value: string) => void
+	onCancel?: () => void
+	placeholder?: string
+	className?: string
+	multiline?: boolean
+	showEditIcon?: boolean
+	onClick?: () => void
+	forceEditing?: boolean
+	ref?: React.Ref<HTMLTextAreaElement | HTMLInputElement>
+	validation?: (value: string) => string | null
+	autoFocus?: boolean
+}
+
+export interface EditableFieldState {
+	isEditing: boolean
+	editValue: string
+}
+

--- a/src/components/organisms/EventDetailsDrawer/EventDetailsDrawer.tsx
+++ b/src/components/organisms/EventDetailsDrawer/EventDetailsDrawer.tsx
@@ -1,9 +1,10 @@
-import { ChevronRight, Clock, ExternalLink, Trash2, X as XIcon } from 'lucide-react'
+import { ChevronRight, Clock, ExternalLink } from 'lucide-react'
 import React, { useEffect, useMemo, useState } from 'react'
 
 import { cn } from '../../../utils/cn'
-import { Button } from '../../atoms/Button'
 import { Drawer } from '../../atoms/Drawer'
+import { DrawerFooter } from '../DrawerFooter'
+import { DrawerHeader } from '../DrawerHeader'
 
 import type { EventDetailsDrawerProps, EventFormData, ValidationErrors } from './types'
 
@@ -93,8 +94,6 @@ export const EventDetailsDrawer: React.FC<EventDetailsDrawerProps> = ({
 
 	const [errors, setErrors] = useState<ValidationErrors>({})
 	const [isSaving, setIsSaving] = useState(false)
-	const [isDeleting, setIsDeleting] = useState(false)
-	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 	const [isDirty, setIsDirty] = useState(false)
 
 	// Initialize form data when event prop changes or drawer opens
@@ -125,7 +124,6 @@ export const EventDetailsDrawer: React.FC<EventDetailsDrawerProps> = ({
 				setIsDirty(false)
 			}
 			setErrors({})
-			setShowDeleteConfirm(false)
 		}
 	}, [isOpen, mode, event, initialStartTime, initialEndTime, initialEventName])
 
@@ -243,7 +241,6 @@ export const EventDetailsDrawer: React.FC<EventDetailsDrawerProps> = ({
 	const handleDelete = async () => {
 		if (!onDelete) return
 
-		setIsDeleting(true)
 		try {
 			await onDelete()
 			setIsDirty(false)
@@ -251,9 +248,6 @@ export const EventDetailsDrawer: React.FC<EventDetailsDrawerProps> = ({
 		} catch (error) {
 			console.error('Failed to delete event:', error)
 			// Could show an error toast here
-		} finally {
-			setIsDeleting(false)
-			setShowDeleteConfirm(false)
 		}
 	}
 
@@ -280,55 +274,13 @@ export const EventDetailsDrawer: React.FC<EventDetailsDrawerProps> = ({
 			contentClassName={isDesktop ? 'w-[500px]' : 'rounded-t-[10px] h-[96%] mt-24'}
 			className="p-0 flex flex-col"
 		>
-			{/* Custom Header with Title, Delete Button, and Close Button */}
-			<div className="flex items-center justify-between p-4 border-b border-border flex-shrink-0">
-				<h2 className="text-lg font-semibold text-foreground">{title}</h2>
-				<div className="flex items-center gap-2">
-					{/* Delete Button (Edit Mode Only) */}
-					{mode === 'edit' && onDelete && (
-						<>
-							{showDeleteConfirm ? (
-								<>
-									<span className="text-sm text-muted-foreground">Delete?</span>
-									<button
-										type="button"
-										onClick={() => setShowDeleteConfirm(false)}
-										disabled={isDeleting}
-										className="py-1.5 px-3 rounded-lg border border-border hover:bg-muted transition-colors text-sm font-medium mobile-touch-target"
-									>
-										Cancel
-									</button>
-									<button
-										type="button"
-										onClick={handleDelete}
-										disabled={isDeleting}
-										className="py-1.5 px-3 rounded-lg bg-destructive hover:bg-destructive/90 text-destructive-foreground transition-colors text-sm font-medium disabled:opacity-50 mobile-touch-target"
-									>
-										{isDeleting ? 'Deleting...' : 'Delete'}
-									</button>
-								</>
-							) : (
-								<button
-									type="button"
-									onClick={() => setShowDeleteConfirm(true)}
-									className="p-2 hover:bg-muted rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-primary/20 mobile-touch-target flex items-center justify-center"
-									aria-label="Delete event"
-								>
-									<Trash2 className="w-4 h-4 text-muted-foreground" />
-								</button>
-							)}
-						</>
-					)}
-					{/* Close Button */}
-					<button
-						onClick={handleClose}
-						className="p-2 hover:bg-muted rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-primary/20 mobile-touch-target flex items-center justify-center"
-						aria-label="Close drawer"
-					>
-						<XIcon size={16} />
-					</button>
-				</div>
-			</div>
+			{/* Header */}
+			<DrawerHeader
+				title={title}
+				onClose={handleClose}
+				showDelete={mode === 'edit' && !!onDelete}
+				onDelete={handleDelete}
+			/>
 
 			{/* Content Area */}
 			<div className="p-4 flex flex-col flex-1 overflow-y-auto">
@@ -542,30 +494,14 @@ export const EventDetailsDrawer: React.FC<EventDetailsDrawerProps> = ({
 				</div>
 			</div>
 
-			{/* Action Buttons - Fixed at Bottom */}
-			<div className="bg-background border-t border-border/30 p-4 flex-shrink-0">
-				<div className="flex flex-col sm:flex-row gap-3">
-					<Button
-						variant="secondary"
-						size="md"
-						onClick={handleClose}
-						disabled={isSaving || isDeleting}
-						className="order-2 sm:order-1 w-full sm:w-auto rounded-lg"
-					>
-						Cancel
-					</Button>
-					<Button
-						variant="default"
-						size="md"
-						onClick={handleSave}
-						disabled={isSaving || isDeleting}
-						loading={isSaving}
-						className="order-1 sm:order-2 w-full sm:w-auto rounded-lg"
-					>
-						{mode === 'create' ? 'Create Event' : 'Save Event'}
-					</Button>
-				</div>
-			</div>
+			{/* Footer */}
+			<DrawerFooter
+				onCancel={handleClose}
+				onSave={handleSave}
+				primaryLabel={mode === 'create' ? 'Create Event' : 'Save Event'}
+				cancelLabel="Cancel"
+				isSaving={isSaving}
+			/>
 		</Drawer>
 	)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,10 @@ export type {
 	ConnectedEventsSectionProps,
 } from './components/molecules/DrawerConnectedSections'
 
+// Molecules - StatusDropdown
+export { StatusDropdown } from './components/molecules/StatusDropdown'
+export type { StatusDropdownProps } from './components/molecules/StatusDropdown'
+
 // Molecules
 export { Card, CardHeader, CardContent, CardFooter } from './components/molecules/Card'
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,46 @@ export type { EditableFieldProps } from './components/atoms/EditableField/Editab
 export { DetailsGrid } from './components/atoms/DetailsGrid/DetailsGrid'
 export type { DetailsGridProps } from './components/atoms/DetailsGrid/DetailsGrid'
 
+// Organisms - EditableField (New versions)
+export {
+	EditableField as EditableFieldOrganism,
+	EditableTextField,
+	EditableTextArea,
+} from './components/organisms/EditableField'
+export type {
+	EditableFieldProps as EditableFieldOrganismProps,
+	EditableTextFieldProps,
+	EditableTextAreaProps,
+} from './components/organisms/EditableField'
+
+// Organisms - Drawer Components
+export { DrawerHeader } from './components/organisms/DrawerHeader'
+export type { DrawerHeaderProps } from './components/organisms/DrawerHeader'
+
+export { DrawerFooter } from './components/organisms/DrawerFooter'
+export type { DrawerFooterProps } from './components/organisms/DrawerFooter'
+
+// Organisms - Connected Sections
+export { ConnectedItemsSection } from './components/organisms/ConnectedItemsSection'
+export type {
+	ConnectedItemsSectionProps,
+	ConnectedItem,
+} from './components/organisms/ConnectedItemsSection'
+
+// Molecules - Drawer Connected Sections
+export {
+	ConnectedElementsSection,
+	ConnectedTasksSection,
+	ConnectedMaterialsSection,
+	ConnectedEventsSection,
+} from './components/molecules/DrawerConnectedSections'
+export type {
+	ConnectedElementsSectionProps,
+	ConnectedTasksSectionProps,
+	ConnectedMaterialsSectionProps,
+	ConnectedEventsSectionProps,
+} from './components/molecules/DrawerConnectedSections'
+
 // Molecules
 export { Card, CardHeader, CardContent, CardFooter } from './components/molecules/Card'
 export type {


### PR DESCRIPTION
# Drawer Component Refactoring Plan
 Our big goal behind this is to have beautifully designed, shared components that abide by our style system and exist in Confetti Design System, and to remove any redundant, re-implemented code. The applied for all The drawers for components: Elements, tasks, material and events
  * keep the delete functionality for all components (Elements, tasks, material and events) like that EventDetailsDrawer where it Has delete button in header , and the confirmation inline
  * keep the functionality for each component (Elements, tasks, material and events) and add to the shared componenet (DrawerFooter) if needed 

  - All drawers use consistent header/footer patterns
- EditableField logic is shared (no duplication)
- Delete confirmation works consistently across all drawers
- Connected sections use shared component
- Mobile/desktop responsive behavior is consistent
- Code reduction: Estimate 40-50% less drawer-related code
- All drawers follow EventDetailsDrawer styling
- No "Modal" naming for Drawer components
- Zero breaking changes to public APIs
-  Reduce the amount of custom design patterns and adhere to the Conce design system.